### PR TITLE
Fix FS issues

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -24,7 +24,10 @@ CFLAGS := -O0 -g -Wall -MMD -MP -nostdinc -fno-builtin \
 #
 ASFLAGS := -g -Wall -MMD -MP -nostdinc -fno-builtin
 #
-LDFLAGS := -ffreestanding
+# -no-pie is required with toolchains producing PIE executables by default
+# (e.g. gcc on Ubuntu >= 18.04). The kernel ELF loader maps segments at
+# their nominal vaddr and cannot relocate position independent executables.
+LDFLAGS := -ffreestanding -no-pie
 #
 # Standard C library relative path
 LDLIBS := $(libc)
@@ -35,8 +38,11 @@ SOURCE_DIR := src
 
 ifeq ($(ARCH),x86)
 
-TARGET_ARCH := -m32
-TARGET_MACH := -m32
+# -march=i686 prevents the compiler from emitting MMX/SSE instructions
+# (default with some toolchains). The kernel doesn't enable SSE (CR4.OSFXSR)
+# nor preserves FPU/SSE context on task switch, so their use traps with #UD.
+TARGET_ARCH := -m32 -march=i686
+TARGET_MACH := -m32 -march=i686
 
 else ifeq ($(ARCH),x86_64)
 

--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -1,14 +1,16 @@
 include ../common.mk
 
 CPPFLAGS += -Isrc -Iinclude
-LDFLAGS  += -nostartfiles
+# -nostdlib avoids any dependency on the host 32-bit shared libraries
+# (libc, libgcc_s). Only the static libgcc is needed (e.g. for __divdi3).
+LDFLAGS  += -nostartfiles -nostdlib
 
 kernel := $(BINARY_DIR)/kernel
- 
+
 all: $(kernel)
-	
+
 $(kernel): $(objects) $(libc)
-	$(LINK.o) $^ -o $@
+	$(LINK.o) $^ -lgcc -o $@
 	#$(OBJCOPY) --only-keep-debug $@ $@.sym
 	cp $@ $@.sym
 	$(STRIP) $@

--- a/misc/mkfs.sh
+++ b/misc/mkfs.sh
@@ -1,21 +1,26 @@
 #!/bin/sh
 
+# Abort on the first error: a partially populated image silently
+# panics the kernel at boot ("init exiting").
+set -e
+
 # Root source
 ROOT_SRC=../user/build/x86
 
-umount /dev/loop0
-losetup -d /dev/loop0
+# Cleanup possible leftovers from a previous failed run
+umount tmp 2>/dev/null || true
 
-# Create the image and make the filesystem
+# Create the image and make the filesystem.
+# The kernel ext2 driver assumes 1024-byte blocks and 128-byte inodes
+# (revision 0 layout). Modern e2fsprogs defaults to 256-byte inodes,
+# which the driver misreads, so the values are forced here.
 dd if=/dev/zero of=disk.img bs=1M count=1
-mkfs.ext2 disk.img
+mkfs.ext2 -F -b 1024 -I 128 disk.img
 
-# Setup loopback device and mount to a temporary directory
-losetup -f
-sleep 1
-losetup /dev/loop0 disk.img
+# Mount using a dynamically allocated loopback device.
+# /dev/loop0 may already be taken (e.g. by snap squashfs images).
 mkdir -p tmp
-mount /dev/loop0 tmp
+mount -o loop disk.img tmp
 
 # Copy the sysroot in the destination
 cp -r sysroot/* tmp/
@@ -36,8 +41,8 @@ for f in $SRC_FILES; do
     cp $f $d
 done
 
-sync
+# Umount the destination and release the loopback device
+umount tmp
+rmdir tmp
 
-# Umount the destination and shutdown the loopback device
-#umount /dev/loop0
-#losetup -d /dev/loop0
+echo "disk.img successfully created"


### PR DESCRIPTION
1. Since e2fsprogs 1.43, `mkfs.ext2` creates filesystems with 256-byte inodes by default, while the kernel ext2 driver assumes the old revision 0 layout with 128-byte inodes. The root inode gets read from the wrong offset, so `named()` fails on the very first path element. `mkfs.sh` now passes `-b 1024 -I 128`.

2. `mkfs.sh` hardcoded `/dev/loop0`. On any host using snap, loop0 is already occupied by a squashfs image, so the mount either failed or mounted the snap read-only and every `cp` failed. Since the README suggests running the script in a subshell, all of this was easy to miss. The script now uses `mount -o loop` (which allocates a free loop device) and aborts on the first error.

3. gcc links executables as PIE by default on most current distros (Ubuntu since 18.04, Arch, ...). The kernel ELF loader maps segments at their nominal vaddr and can't relocate PIE binaries, so even with a good disk image `/sbin/init` couldn't start. Depending on the toolchain's 32-bit defaults, gcc could also emit SSE instructions, which trap with #UD since the kernel never enables SSE. The build now uses `-no-pie` and `-march=i686`.

Verified on a current toolchain (gcc 16, e2fsprogs 1.47): `make all && (cd misc && sudo ./mkfs.sh && ./qemu.sh)` boots to the shell prompt.

Closes #27 